### PR TITLE
Bump actions/github-script from v5 to v6

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Get latest run results
-      uses: actions/github-script@v5.0.0
+      uses: actions/github-script@v6
       id: get-runs
       with:
         script: |


### PR DESCRIPTION
Ref.  https://github.com/equinor/Solum/issues/12722

Action needs to be updated from version 5 to version 6. 
This is because `The following actions uses node12 which is deprecated and will be forced to run on node16`