### PR TITLE
Bump actions/github-script@v6 to actions/github-script@v7

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
     - name: Get latest run results
-      uses: actions/github-script@v6
+      uses: actions/github-script@v7
       id: get-runs
       with:
         script: |


### PR DESCRIPTION
Bump Action from 6 to 7.
Tested in Solum repo OK.
![image](https://github.com/equinor/pipeline-health/assets/65277007/55caee0a-2c97-475d-b2a0-9b145505b113)

