### PR TITLE
Enable Dependabot for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
**Reference to issue(s):**

- equinor/Solum#14502

**Changes in this PR (list):**

    1. Add dependabot.yml
    2. Please do the steps 1-4 before merging PR 
    - [Enable Dependabot](https://docs.github.com/en/code-security/getting-started/dependabot-quickstart-guide#enabling-dependabot-for-your-repository)
    

**Reference to tests**
- Tested in Solum repo

**Risk analysis** (Short risk analysis of the change)
- Low risk, dependabot helps securing repo.

**Fallback plan** (How to revert to last known good state)
- Disable dependabot

**Other relevant information**: